### PR TITLE
fix: hide placeholder during IME composition (Quill v2 workaround)

### DIFF
--- a/demo/src/examples/BasicExample.vue
+++ b/demo/src/examples/BasicExample.vue
@@ -1,6 +1,6 @@
 <template>
   <h1>Basic Example</h1>
-  <QuillEditor v-model:content="content" />
+  <QuillEditor v-model:content="content" placeholder="type something..."/>
 </template>
 
 <script lang="ts">

--- a/packages/vue-quill-next/src/components/QuillEditor.ts
+++ b/packages/vue-quill-next/src/components/QuillEditor.ts
@@ -157,6 +157,16 @@ export const QuillEditor = defineComponent({
           e.preventDefault()
         },
       )
+      // https://github.com/slab/quill/issues/4021
+      // Patch for Quill v2 bug: placeholder not hidden during IME composition
+      quill.root.addEventListener('compositionstart', () => {
+        quill?.root.classList.remove('ql-blank')
+      })
+      quill.root.addEventListener('compositionend', () => {
+        if (!quill?.root.textContent?.trim()) {
+          quill?.root.classList.add('ql-blank')
+        }
+      })
       // Emit ready event
       ctx.emit('ready', quill)
     }


### PR DESCRIPTION
https://github.com/babu-ch/vue-quill/issues/49