### PR TITLE
refactor(css)!: rename css files from vue-quill.*.css to vue-quill-next

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ main.ts
 import { createApp } from 'vue'
 import App from './App.vue'
 import {QuillEditor} from 'vue-quill-next'
-import 'vue-quill-next/dist/vue-quill.snow.css';
+import 'vue-quill-next/dist/vue-quill-next.snow.css';
 
 const app = createApp(App)
 

--- a/demo/src/main.ts
+++ b/demo/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 import App from './App.vue'
 
-import 'vue-quill-next/dist/vue-quill.bubble.css'
-import 'vue-quill-next/dist/vue-quill.snow.css'
+import 'vue-quill-next/dist/vue-quill-next.bubble.css'
+import 'vue-quill-next/dist/vue-quill-next.snow.css'
 
 createApp(App).mount('#app')

--- a/docs/content/.vitepress/theme/index.ts
+++ b/docs/content/.vitepress/theme/index.ts
@@ -12,9 +12,9 @@ const QuillEditor = defineAsyncComponent({
   loadingComponent: Loading,
 })
 
-import 'vue-quill-next/dist/vue-quill.core.css' // import styles
-import 'vue-quill-next/dist/vue-quill.bubble.css' // for bubble theme
-import 'vue-quill-next/dist/vue-quill.snow.css' // for snow theme
+import 'vue-quill-next/dist/vue-quill-next.core.css' // import styles
+import 'vue-quill-next/dist/vue-quill-next.bubble.css' // for bubble theme
+import 'vue-quill-next/dist/vue-quill-next.snow.css' // for snow theme
 
 export default {
   ...Theme,

--- a/docs/content/guide/installation.md
+++ b/docs/content/guide/installation.md
@@ -16,11 +16,11 @@ VueQuillNext ships as a UMD module that is accessible in the browser. When loade
 
 <!-- use the latest VueQuillNext release -->
 <script src="https://unpkg.com/vue-quill-next@latest"></script>
-<link rel="stylesheet" href="https://unpkg.com/vue-quill-next@latest/dist/vue-quill.snow.prod.css">
+<link rel="stylesheet" href="https://unpkg.com/vue-quill-next@latest/dist/vue-quill-next.snow.prod.css">
 
 <!-- or point to a specific VueQuillNext release -->
 <script src="https://unpkg.com/vue-quill-next@version"></script>
-<link rel="stylesheet" href="https://unpkg.com/vue-quill-next@version/dist/vue-quill.snow.prod.css">
+<link rel="stylesheet" href="https://unpkg.com/vue-quill-next@version/dist/vue-quill-next.snow.prod.css">
 ```
 
 ::: warning 

--- a/docs/content/guide/modules.md
+++ b/docs/content/guide/modules.md
@@ -24,7 +24,7 @@ yarn add quill-blot-formatter
 import { ref, defineComponent } from 'vue'
 import { QuillEditor } from 'vue-quill-next'
 import BlotFormatter from 'quill-blot-formatter'
-import 'vue-quill-next/dist/vue-quill.snow.css'
+import 'vue-quill-next/dist/vue-quill-next.snow.css'
 
 export default defineComponent({
   components: {
@@ -59,7 +59,7 @@ npm install quill-image-uploader --save
 <script>
 import { ref, defineComponent } from 'vue'
 import { QuillEditor } from 'vue-quill-next'
-import 'vue-quill-next/dist/vue-quill.snow.css'
+import 'vue-quill-next/dist/vue-quill-next.snow.css'
 import ImageUploader from 'quill-image-uploader';
 import axios from '../lib/axios';
 

--- a/docs/content/guide/options.md
+++ b/docs/content/guide/options.md
@@ -11,7 +11,7 @@ Only use `options` prop when you register QuillEditor component locally
 - **Usage:**
   ``` javascript
   import { QuillEditor } from 'vue-quill-next'
-  import 'vue-quill-next/dist/vue-quill.snow.css';
+  import 'vue-quill-next/dist/vue-quill-next.snow.css';
 
   export default {
     components: {

--- a/docs/content/guide/themes.md
+++ b/docs/content/guide/themes.md
@@ -6,9 +6,9 @@ Themes primarily control the visual look of Quill through its CSS stylesheet, an
 To activate a theme, import the stylesheet for the themes you want to use.
 
 ~~~ javascript
-import 'vue-quill-next/dist/vue-quill.snow.css';
+import 'vue-quill-next/dist/vue-quill-next.snow.css';
 // OR | AND
-import 'vue-quill-next/dist/vue-quill.bubble.css';
+import 'vue-quill-next/dist/vue-quill-next.bubble.css';
 // you can use both themes at the same time and use them interchangeably
 ~~~
 

--- a/docs/content/guide/usage.md
+++ b/docs/content/guide/usage.md
@@ -26,7 +26,7 @@ We're showing you a simple example here, but in a typical Vue application, we us
 ``` javascript
 import { createApp } from 'vue'
 import { QuillEditor } from 'vue-quill-next'
-import 'vue-quill-next/dist/vue-quill.snow.css';
+import 'vue-quill-next/dist/vue-quill-next.snow.css';
 
 const app = createApp()
 app.component('QuillEditor', QuillEditor)
@@ -36,7 +36,7 @@ app.component('QuillEditor', QuillEditor)
 
 ``` javascript
 import { QuillEditor } from 'vue-quill-next'
-import 'vue-quill-next/dist/vue-quill.snow.css';
+import 'vue-quill-next/dist/vue-quill-next.snow.css';
 
 export default {
   components: {
@@ -55,7 +55,7 @@ export default {
 
 ::: tip NOTE
 The component itself does not include any CSS theme. You'll need to include it separately:
-`import 'vue-quill-next/dist/vue-quill.snow.css'` or `import 'vue-quill-next/dist/vue-quill.bubble.css'`
+`import 'vue-quill-next/dist/vue-quill-next.snow.css'` or `import 'vue-quill-next/dist/vue-quill-next.bubble.css'`
 :::
 
 ## Using v-model:content

--- a/examples/vite-app/src/main.ts
+++ b/examples/vite-app/src/main.ts
@@ -1,7 +1,7 @@
 import { createApp } from 'vue'
 // VueQuill
 import { QuillEditor } from 'vue-quill-next'
-import 'vue-quill-next/dist/vue-quill.snow.css'
+import 'vue-quill-next/dist/vue-quill-next.snow.css'
 // VueHighlightJS
 import VueHighlightJS from 'vue3-highlightjs'
 import 'highlight.js/styles/solarized-light.css'

--- a/packages/vue-quill-next/README.md
+++ b/packages/vue-quill-next/README.md
@@ -12,7 +12,7 @@ main.ts
 import { createApp } from 'vue'
 import App from './App.vue'
 import {QuillEditor} from 'vue-quill-next'
-import 'vue-quill-next/dist/vue-quill.snow.css';
+import 'vue-quill-next/dist/vue-quill-next.snow.css';
 
 const app = createApp(App)
 

--- a/packages/vue-quill-next/assets.config.json
+++ b/packages/vue-quill-next/assets.config.json
@@ -2,15 +2,15 @@
   "css": [
     {
       "input": "./node_modules/quill/assets/core.styl",
-      "output": "./dist/vue-quill.core.css"
+      "output": "./dist/vue-quill-next.core.css"
     },
     {
       "input": "./node_modules/quill/assets/bubble.styl",
-      "output": "./dist/vue-quill.bubble.css"
+      "output": "./dist/vue-quill-next.bubble.css"
     },
     {
       "input": "./src/assets/snow.styl",
-      "output": "./dist/vue-quill.snow.css"
+      "output": "./dist/vue-quill-next.snow.css"
     }
   ]
 }


### PR DESCRIPTION
We decided to unify the css name along with the package name.
