### PR TITLE
docs: add deprecation notice pointing to @vueup/vue-quill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
-> 🧩 **Maintained fork** of [vueup/vue-quill](https://github.com/vueup/vue-quill)
-> 
-> ✨ Updated for **Quill v2** compatibility.
-> 
-> If you have @types/quill installed, uninstall it, as it is no longer needed
+> [!WARNING]
+> **`vue-quill-next` is winding down.** The original [@vueup/vue-quill](https://github.com/vueup/vue-quill) is actively maintained again — please use it instead:
+> **[npm](https://www.npmjs.com/package/@vueup/vue-quill)** · **[repo](https://github.com/vueup/vue-quill)**.
+> Both target **Quill v2**, so migrating is mostly a package/import rename.
 
 # install
 

--- a/docs/content/guide/index.md
+++ b/docs/content/guide/index.md
@@ -2,8 +2,8 @@
 
 <div class="replaceable-area">
 
-::: warning
-🚀 **VueQuillNext** is in **@beta** version! Currently the focus is on making VueQuill stable and feature complete first. It is not recommended to use this for anything serious yet. Some of its features are not "finalized" and will have breaking changes over time as we discover better solutions.
+::: warning Deprecated
+**VueQuillNext (`vue-quill-next`) is winding down.** The original [@vueup/vue-quill](https://www.npmjs.com/package/@vueup/vue-quill) is actively maintained again — please use it instead. Both target Quill v2, so migrating is mostly a package/import rename.
 :::
 
 </div>

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -30,3 +30,7 @@ features:
     title: Easy To Use
     details: Straightforward implementation through a simple API.
 ---
+
+::: warning Deprecated
+**VueQuillNext (`vue-quill-next`) is winding down.** The original [@vueup/vue-quill](https://www.npmjs.com/package/@vueup/vue-quill) is actively maintained again — please use it instead. Both target Quill v2, so migrating is mostly a package/import rename.
+:::

--- a/packages/vue-quill-next/README.md
+++ b/packages/vue-quill-next/README.md
@@ -1,8 +1,7 @@
-> 🧩 **Maintained fork** of [vueup/vue-quill](https://github.com/vueup/vue-quill)
->
-> ✨ Updated for **Quill v2** compatibility.
->
-> If you have @types/quill installed, uninstall it, as it is no longer needed
+> [!WARNING]
+> **`vue-quill-next` is winding down.** The original [@vueup/vue-quill](https://github.com/vueup/vue-quill) is actively maintained again — please use it instead:
+> **[npm](https://www.npmjs.com/package/@vueup/vue-quill)** · **[repo](https://github.com/vueup/vue-quill)**.
+> Both target **Quill v2**, so migrating is mostly a package/import rename.
 
 
 # usage


### PR DESCRIPTION
The original [@vueup/vue-quill](https://github.com/vueup/vue-quill) appears to be actively maintained again, so this fork (`vue-quill-next`) is being deprecated in favor of it.

This PR adds a deprecation notice to the READMEs and docs.